### PR TITLE
increase pingTimeout and bufferSize

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,8 +39,8 @@ const io = socketIO(server, {
         res.writeHead(200, headers);
         res.end();
     },
-    maxHttpBufferSize: 10e6,
-    pingTimeout: 10000
+    maxHttpBufferSize: 20e6,
+    pingTimeout: 60000
 });
 
 // listens on host:9090/metrics


### PR DESCRIPTION
quickly addressing [possible reasons](https://socket.io/docs/v4/troubleshooting-connection-issues/#possible-explanations-1) the sockets might disconnect with 'transport close' - although a bump to v4 seems inevitable 