### PR TITLE
fix: restore USER_LIMIT feature for Socket.IO v4

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ dotenv.config(
 
 const app = express();
 const port = process.env.PORT || (process.env.NODE_ENV === 'development' ? 3002 : 80); // default port to listen
+const userLimit = Number(process.env.USER_LIMIT) || Infinity;
 
 app.use(express.static('public'));
 
@@ -64,6 +65,15 @@ io.on('connection', socket => {
         serverDebug(`${socket.id} has joined ${roomID} for url ${socket.conn.request.url}`);
         await socket.join(roomID);
         const sockets = await io.in(roomID).fetchSockets();
+
+        if (sockets.length > userLimit) {
+            serverDebug(`${socket.id} rejected from ${roomID}: user limit (${userLimit}) reached`);
+            socket.emit('room-full');
+            socket.leave(roomID);
+            socket.disconnect(true);
+
+            return;
+        }
 
         if (sockets.length <= 1) {
             io.to(`${socket.id}`).emit('first-in-room');


### PR DESCRIPTION
The USER_LIMIT feature (originally added in 5edc587) was accidentally
removed during the Socket.IO v4 upgrade in #24.

This PR restores the user limit enforcement using v4 APIs:
- Reads USER_LIMIT from environment variable (defaults to Infinity)
- Checks room occupancy after join using fetchSockets()
- Rejects only the new connection when limit is exceeded (emits
  'room-full', leaves room, disconnects)

Unlike the original v2 implementation which disconnected all users
when the limit was hit, this version only rejects the incoming user.

Ref: https://github.com/jitsi/excalidraw-backend/pull/24#issuecomment-3696961426