### PR TITLE
chore: scope package name to @jitsi/excalidraw-backend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "excalidraw-backend",
+    "name": "@jitsi/excalidraw-backend",
     "version": "2026.3.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "excalidraw-backend",
+            "name": "@jitsi/excalidraw-backend",
             "version": "2026.3.0",
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "excalidraw-backend",
+    "name": "@jitsi/excalidraw-backend",
     "version": "2026.3.0",
     "main": "src/index.js",
     "description": "Excalidraw backend",


### PR DESCRIPTION
Switches the bare name to the `@jitsi` scope. No functional change.

The Docker image tag (`jitsi/excalidraw-backend`) and the Dockerfile `WORKDIR` are independent of `package.json:name` and are intentionally left unchanged.